### PR TITLE
Add link to Mirror Design System

### DIFF
--- a/src/content/developers/docs/design-and-ux/index.md
+++ b/src/content/developers/docs/design-and-ux/index.md
@@ -72,3 +72,4 @@ Get involved in professional community-driven organizations or join design group
 - [Ethereum.org Design system](https://www.figma.com/@ethdotorg) (Figma)
 - [Finity, a design system for Web3 by Polygon](https://finity.polygon.technology/) (Figma)
 - [ENS Design system](https://thorin.ens.domains/)
+- [Mirror Design System](https://degen-xyz.vercel.app/)


### PR DESCRIPTION
The Mirror Design System was linked at the bottom of the ENS Design System repo. I figured it would be awesome to include it as well.

Here's the link: [Mirror Design System](https://degen-xyz.vercel.app/), and here's the [github repo](https://github.com/mirror-xyz/degen/tree/main) for anyone who's curious.
